### PR TITLE
Job.track() stops polling if no callbacks after ready() are registered.

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -2921,8 +2921,9 @@
             callbacks.failed = callbacks.failed || function() {};
             callbacks.error = callbacks.error || function() {};
             
+            // For use by tests only
             callbacks._preready = callbacks._preready || function() {};
-            callbacks._stoppedafterready = callbacks._stoppedafterready || function() {};
+            callbacks._stoppedAfterReady = callbacks._stoppedAfterReady || function() {};
             
             var that = this;
             var emittedReady = false;
@@ -2948,7 +2949,7 @@
                                 // Optimization: Don't keep polling the job if the
                                 // caller only cares about the `ready` event.
                                 if (noCallbacksAfterReady) {
-                                    callbacks._stoppedafterready(job);
+                                    callbacks._stoppedAfterReady(job);
                                     
                                     doneLooping = true;
                                     nextIteration();

--- a/tests/test_service.js
+++ b/tests/test_service.js
@@ -1060,7 +1060,7 @@ exports.setup = function(svc, loggedOutSvc) {
                             test.ok(job);
                         },
                         
-                        _stoppedafterready: function(job) {
+                        _stoppedAfterReady: function(job) {
                             test.done();
                         }
                     });
@@ -1068,6 +1068,7 @@ exports.setup = function(svc, loggedOutSvc) {
             },
             
             "Callback#track() a job that is not immediately ready": function(test) {
+                /*jshint loopfunc:true */
                 var numJobs = 20;
                 var numJobsLeft = numJobs;
                 var gotJobNotImmediatelyReady = false;


### PR DESCRIPTION
Also:
- Job.track() detects non-ready state correctly.
