### PR TITLE
Exclude generated (but checked in) files from diffs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Exclude generated (but checked in) files from diffs
+# These lines only work once you run the following command locally:
+#   git config diff.nodiff.command true
+client/* diff=nodiff
+node_modules/* diff=nodiff
+node_modules/*/* diff=nodiff
+node_modules/*/*/* diff=nodiff
+node_modules/*/*/*/* diff=nodiff
+node_modules/*/*/*/*/* diff=nodiff
+node_modules/*/*/*/*/*/* diff=nodiff
+node_modules/*/*/*/*/*/*/* diff=nodiff
+node_modules/*/*/*/*/*/*/*/* diff=nodiff
+node_modules/*/*/*/*/*/*/*/*/* diff=nodiff
+node_modules/*/*/*/*/*/*/*/*/*/* diff=nodiff


### PR DESCRIPTION
As a test, try:

> git diff e249b67e68 9a581aa6ce

_without_ running `git config diff.nodiff.command true` beforehand. You should still see the generated files.

Now run that command above and try the diff again. The generated files should vanish.
