### PR TITLE
Add strictSSL option to support node.js v0.8+

### DIFF
--- a/lib/platform/node/node_http.js
+++ b/lib/platform/node/node_http.js
@@ -1,4 +1,3 @@
-
 // Copyright 2011 Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"): you may
@@ -32,7 +31,8 @@
                 headers: message.headers || {},
                 body: message.body || "",
                 jar: false,
-                followAllRedirects: true
+                followAllRedirects: true,
+                strictSSL: false
             };
             
             request_options.headers["Content-Length"] = request_options.body.length;


### PR DESCRIPTION
rejectUnauthorized was introduced in node 0.8 if the https module doesn't find a trusted certificate (like splunk self generated case) then it fails to connect giving a "Error: SELF_SIGNED_CERT_IN_CHAIN" message.

Request module already provide strictSSL option to prevent this problem (I test on v2.16.3) but it's not work with version require by this sdk (v2.9.152).

I fix this problem by upgrade request module to v2.16.3 then edit lib/platform/node/node_http.js file to add "strictSSL: false" to option
