### PR TITLE
Add an 'options' parameter for FiredAlertGroup.list function to allow passing options when retrieving fired alerts.

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -1976,7 +1976,7 @@
 
         /**
          * Returns fired instances of this alert, which is
-         * a list of `splunkjs.Service.Job` instances.
+         * a list of `splunkjs.Service.FiredAlert` instances.
          *
          * @example
          *
@@ -1987,15 +1987,21 @@
          *          }
          *      });
          *
-         * @param {Function} callback A function to call when the history is retrieved: `(err, firedAlerts, alertGroup)`.
+         * @param {Function} callback A function to call when the alerts are retrieved: `(err, firedAlerts, alertGroup)`.
          *
          * @method splunkjs.Service.FiredAlertGroup
          */
-        list: function(callback) {
+        list: function(options, callback) {
+            if (!callback && utils.isFunction(options)) {
+                callback = options;
+                options = {};
+            }
             callback = callback || function() {};
             
+            options = options || {};
+   
             var that = this;
-            return this.get("", {}, function(err, response) {
+            return this.get("", options, function(err, response) {
                 if (err) {
                     callback(err);
                     return;


### PR DESCRIPTION
Pull request to expose 'options' parameter when sending GET request to retrieve fired alerts.
