### PR TITLE
Jobs constructor expects two arguments - service and namespace only.

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -360,7 +360,7 @@
                 namespace = null;
             }
             
-            var jobs = new root.Jobs(this, {}, namespace);
+            var jobs = new root.Jobs(this, namespace);
             return jobs.search(query, params, callback);
         },
         


### PR DESCRIPTION
See Jobs construction definition https://github.com/splunk/splunk-sdk-javascript/blob/d17d9639eb72671fb5eb3f54eb85f4369cfbf5af/lib/service.js#L3558-L3564 it expects only `service` and `namespace` for init.
