### PR TITLE
Fix Examples Under NodeJS 0.12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "uglify-js" : "1.1.x",
         "nodeunit" : "0.9.x",
         "jshint" : "0.5.x >= 0.5.4",
-        "mustache": "0.3.x",
+        "mustache": "0.4.x",
         "readable-stream" : "1.1.13-1"
     },
     "author" : {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "javascript"
     ],
     "dependencies" : {
-        "request" : "2.21.x",
+        "request" : "2.55.x",
         "elementtree" : "0.1.6"
     },
     "devDependencies" : {


### PR DESCRIPTION
This pull request fixes #38 

Update request dependency to 2.55.x, which resolves the issue breaking examples: https://github.com/request/request/issues/1522

Also, update Mustache version to 0.4.x since 0.3.x is not valid. This version is still way out of date, consider upgrading to the latest: 2.0.0

I have only done a basic smoke test of my changes against v0.10.36 and v0.12.2, but the updated version of request could cause other issues. The previous version was quite far behind the latest.