### PR TITLE
Make writing to stdout/stderr blocking in modular inputs.

### DIFF
--- a/lib/modularinputs/index.js
+++ b/lib/modularinputs/index.js
@@ -35,12 +35,8 @@ var ModularInputs = {
  */
 ModularInputs.execute = function(exports, module) {
     if (require.main === module) {
-        var args = process.argv;
-
-        // Trim the first argument, if it is the node.js executable.
-        if (args[0] === 'node' || ModularInputs.utils.contains(args[0], 'node.exe')) {
-            args = args.slice(1, args.length);
-        }
+        // Slice process.argv ignoring the first argument as it is the path to the node executable.
+        var args = process.argv.slice(1);
 
         // Default empty functions for life cycle events.
         exports.setup       = exports.setup     || ModularInputs.ModularInput.prototype.setup;

--- a/lib/modularinputs/index.js
+++ b/lib/modularinputs/index.js
@@ -56,6 +56,13 @@ ModularInputs.execute = function(exports, module) {
         // by ModularInput.runScript().
         var ew = new this.EventWriter();
 
+        // In order to ensure that everything that is written to stdout/stderr is flushed before we exit,
+        // set the file handles to blocking. This ensures we exit properly in a timely fashion.
+        // https://github.com/nodejs/node/issues/6456
+        [process.stdout, process.stderr].forEach(function(s) {
+          s && s.isTTY && s._handle && s._handle.setBlocking && s._handle.setBlocking(true);
+        });
+
         var scriptStatus;
         Async.chain([
                 function(done) {
@@ -74,10 +81,7 @@ ModularInputs.execute = function(exports, module) {
                     ModularInputs.Logger.error('', err, ew._err);
                 }
 
-                // Wait for process.stdout to drain before exiting the process.
-                process.stdout.once("drain", function() {
-                    process.exit(scriptStatus || err ? 1 : 0);
-                });
+                process.exit(scriptStatus || err ? 1 : 0);
             }
         );
     }

--- a/lib/modularinputs/modularinput.js
+++ b/lib/modularinputs/modularinput.js
@@ -61,7 +61,8 @@
         var that = this;
 
         // Resume streams before trying to read their data.
-        if (inputStream.resume) {
+        // If the inputStream is a TTY, we don't want to open the stream as it will hold the process open.
+        if (inputStream.resume && !inputStream.isTTY) {
             inputStream.resume();
         }
         var bigBuff = new Buffer(0);


### PR DESCRIPTION
This lets us rely on output being flushed whenever we exit instead of
waiting for 'drain' to happen, which doesn't ever happen.

This is related to an issue that prevents modular inputs from using external validation properly.