### PR TITLE
cmdLine.opts is incorrect

### DIFF
--- a/examples/node/search.js
+++ b/examples/node/search.js
@@ -174,7 +174,7 @@
         
         cmdline.parse(argv);
         
-        var service = createService(cmdline.opts);
+        var service = createService(cmdline);
         service.login(function(err, success) {
             if (err || !success) {
                 callback("Error logging in");


### PR DESCRIPTION
it may be this is using a much older version of cmdLine, but today the options get appended to the base object.