### PR TITLE
Restore clear_password property for StoragePasswords creation

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -1904,6 +1904,15 @@
      */
     root.StoragePasswords = root.Collection.extend({
         /**
+         * Indicates whether to call `fetch` after an entity has been created. By 
+         * default, the entity is not fetched because the endpoint returns
+         * (echoes) the new entity.
+         *
+         * @method splunkjs.Service.StoragePasswords
+         */
+        fetchOnEntityCreation: true,
+
+        /**
          * Retrieves the REST endpoint path for this resource (with no namespace).
          *
          * @method splunkjs.Service.StoragePasswords

--- a/tests/service_tests/storagepasswords.js
+++ b/tests/service_tests/storagepasswords.js
@@ -29,6 +29,7 @@ module.exports = function(svc) {
                     function(storagePassword, done) {
                         test.strictEqual(name, storagePassword.properties().username);
                         test.strictEqual(realm + ":" + name + ":", storagePassword.name);
+                        test.strictEqual("changeme", storagePassword.properties().clear_password);
                         test.strictEqual(realm, storagePassword.properties().realm);
                         that.service.storagePasswords().fetch(Async.augment(done, storagePassword));
                     },
@@ -67,6 +68,7 @@ module.exports = function(svc) {
                     function(storagePassword, done) {
                         test.strictEqual(name, storagePassword.properties().username);
                         test.strictEqual("\\" + realm + ":\\" + name + ":", storagePassword.name);
+                        test.strictEqual("changeme", storagePassword.properties().clear_password);
                         test.strictEqual(realm, storagePassword.properties().realm);
                         that.service.storagePasswords().fetch(Async.augment(done, storagePassword));
                     },
@@ -105,6 +107,7 @@ module.exports = function(svc) {
                     function(storagePassword, done) {
                         test.strictEqual(name, storagePassword.properties().username);
                         test.strictEqual(realm + ":" + name + ":", storagePassword.name);
+                        test.strictEqual("changeme", storagePassword.properties().clear_password);
                         test.strictEqual(realm, storagePassword.properties().realm);
                         that.service.storagePasswords().fetch(Async.augment(done, storagePassword));
                     },
@@ -142,6 +145,7 @@ module.exports = function(svc) {
                     function(storagePassword, done) {
                         test.strictEqual(name, storagePassword.properties().username);
                         test.strictEqual(":" + name + ":", storagePassword.name);
+                        test.strictEqual("changeme", storagePassword.properties().clear_password);
                         test.strictEqual("", storagePassword.properties().realm);
                         that.service.storagePasswords().fetch(Async.augment(done, storagePassword));
                     },
@@ -231,6 +235,7 @@ module.exports = function(svc) {
                     function(storagePassword, done) {
                         test.strictEqual(name, storagePassword.properties().username);
                         test.strictEqual("\\" + realm + ":\\" + name + ":", storagePassword.name);
+                        test.strictEqual("changeme", storagePassword.properties().clear_password);
                         test.strictEqual(realm, storagePassword.properties().realm);
                         that.service.storagePasswords().fetch(Async.augment(done, storagePassword));
                     },
@@ -273,6 +278,7 @@ module.exports = function(svc) {
                     function(storagePassword, done) {
                         test.strictEqual(name + ":end!@#$%^&*()_+{}:|<>?", storagePassword.properties().username);
                         test.strictEqual("\\:start\\:\\:!@#$%^&*()_+{}\\:|<>?" + realm + ":" + name + "\\:end!@#$%^&*()_+{}\\:|<>?:", storagePassword.name);
+                        test.strictEqual("changeme", storagePassword.properties().clear_password);
                         test.strictEqual(":start::!@#$%^&*()_+{}:|<>?" + realm, storagePassword.properties().realm);
                         that.service.storagePasswords().fetch(Async.augment(done, storagePassword));
                     },
@@ -315,6 +321,7 @@ module.exports = function(svc) {
                     function(storagePassword, done) {
                         test.strictEqual(name + ":end!@#$%^&*()_+{}:|<>?쎼 and 쎶 and &lt;&amp;&gt; für", storagePassword.properties().username);
                         test.strictEqual("\\:start\\:\\:!@#$%^&*()_+{}\\:|<>?" + encodeURIComponent("쎼 and 쎶 and &lt;&amp;&gt; für") + realm + ":" + name + "\\:end!@#$%^&*()_+{}\\:|<>?쎼 and 쎶 and &lt;&amp;&gt; für:", storagePassword.name);
+                        test.strictEqual(decodeURIComponent(encodeURIComponent("쎼 and 쎶 and &lt;&amp;&gt; für")), storagePassword.properties().clear_password);
                         test.strictEqual(":start::!@#$%^&*()_+{}:|<>?" + encodeURIComponent("쎼 and 쎶 and &lt;&amp;&gt; für") + realm, storagePassword.properties().realm);
                         that.service.storagePasswords().fetch(Async.augment(done, storagePassword));
                     },
@@ -353,6 +360,7 @@ module.exports = function(svc) {
                     function(storagePassword, done) {
                         test.strictEqual(name, storagePassword.properties().username);
                         test.strictEqual(realm + ":" + name + ":", storagePassword.name);
+                        test.strictEqual("changeme", storagePassword.properties().clear_password);
                         test.strictEqual(realm, storagePassword.properties().realm);
                         that.service.storagePasswords().fetch(Async.augment(done, storagePassword));
                     },
@@ -408,6 +416,7 @@ module.exports = function(svc) {
                     function(storagePassword, done) {
                         test.strictEqual(name, storagePassword.properties().username);
                         test.strictEqual(realm + ":" + name + ":", storagePassword.name);
+                        test.strictEqual("changeme", storagePassword.properties().clear_password);
                         test.strictEqual(realm, storagePassword.properties().realm);
                         that.service.storagePasswords().fetch(Async.augment(done, storagePassword));
                     },
@@ -463,6 +472,7 @@ module.exports = function(svc) {
                     function(storagePassword, done) {
                         test.strictEqual(name, storagePassword.properties().username);
                         test.strictEqual(realm + ":" + name + ":", storagePassword.name);
+                        test.strictEqual("changeme", storagePassword.properties().clear_password);
                         test.strictEqual(realm, storagePassword.properties().realm);
                         that.service.storagePasswords().fetch(Async.augment(done, storagePassword));
                     },
@@ -473,6 +483,7 @@ module.exports = function(svc) {
                     function(storagePassword, done) {
                         test.strictEqual(name, storagePassword.properties().username);
                         test.strictEqual(realm + ":" + name + ":", storagePassword.name);
+                        test.strictEqual("changed", storagePassword.properties().clear_password);
                         test.strictEqual(realm, storagePassword.properties().realm);
                         that.service.storagePasswords().fetch(done);
                     },
@@ -488,6 +499,7 @@ module.exports = function(svc) {
                                 index = i;
                                 test.strictEqual(name, list[i].properties().username);
                                 test.strictEqual(realm + ":" + name + ":", list[i].name);
+                                test.strictEqual("changed", list[i].properties().clear_password);
                                 test.strictEqual(realm, list[i].properties().realm);
                             }
                         }
@@ -531,6 +543,7 @@ module.exports = function(svc) {
                     function(storagePassword, done) {
                         test.strictEqual(name, storagePassword.properties().username);
                         test.strictEqual(realm + ":" + name + ":", storagePassword.name);
+                        test.strictEqual("changeme", storagePassword.properties().clear_password);
                         test.strictEqual(realm, storagePassword.properties().realm);
                         that.service.storagePasswords().fetch(Async.augment(done, storagePassword));
                     },
@@ -562,6 +575,7 @@ module.exports = function(svc) {
                                 index = i;
                                 test.strictEqual(name, list[i].properties().username);
                                 test.strictEqual(realm + ":" + name + ":", list[i].name);
+                                test.strictEqual("changeme", list[i].properties().clear_password);
                                 test.strictEqual(realm, list[i].properties().realm);
                             }
                         }


### PR DESCRIPTION
Followup to: https://github.com/splunk/splunk-sdk-javascript/pull/86

After discussion with @dgao1029 I think the most backwards compatible approach is to follow the Java SDK and perform a subsequent GET after the password is created so that the `clear_password` property is available for SDK users even though it's no longer returned in the POST response.