### PR TITLE
Add pagination support to history calls

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -1704,22 +1704,29 @@
          * @example
          *
          *      var savedSearch = service.savedSearches().item("MySavedSearch");
-         *      savedSearch.history(function(err, jobs, search) {
+         *      savedSearch.history({count: 10}, function(err, jobs, search) {
          *          for(var i = 0; i < jobs.length; i++) {
          *              console.log("Job", i, ":", jobs[i].sid);
          *          }
          *      });
          *
+         * @param {Object} options Options for retrieving history. For a full list, see the <a href="https://docs.splunk.com/Documentation/Splunk/8.0.2/RESTREF/RESTprolog#Pagination_and_filtering_parameters" target="_blank">Pagination and Filtering options</a> in the REST API documentation.
          * @param {Function} callback A function to call when the history is retrieved: `(err, job, savedSearch)`.
          *
          * @endpoint saved/searches/{name}/history
          * @method splunkjs.Service.SavedSearch
          */
-        history: function(callback) {
+        history: function(options, callback) {
+            if (!callback && utils.isFunction(options)) {
+                callback = options;
+                options = {};
+            }
+            
             callback = callback || function() {};
+            options = options || {};
             
             var that = this;
-            return this.get("history", {}, function(err, response) {
+            return this.get("history", options, function(err, response) {
                 if (err) {
                     callback(err);
                     return;


### PR DESCRIPTION
Although the REST docs don't mention it, the history call accepts
pagination parameters. Without passing parameters, a default of only
30 results will be returned.