### PR TITLE
SessionKey wrongly called/ checked

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -309,8 +309,8 @@
             var wrappedCallback = function(err, response) {
                 // Let's make sure that not only did the request succeed, but
                 // we actually got a non-empty session key back.
-                let resData = response.data,
-                    resSessionKey;
+                var resData = response.data;
+                var resSessionKey;
                 if(resData){
                     resSessionKey = JSON.parse(resData).sessionKey;  
                 }

--- a/lib/context.js
+++ b/lib/context.js
@@ -309,9 +309,10 @@
             var wrappedCallback = function(err, response) {
                 // Let's make sure that not only did the request succeed, but
                 // we actually got a non-empty session key back.
-                var resData = response.data;
+                var resData;
                 var resSessionKey;
-                if(resData){
+                if(!err && response.data){
+                    resData = response.data;
                     resSessionKey = JSON.parse(resData).sessionKey;  
                 }
                 var hasSessionKey = !!(!err && resData && resSessionKey);

--- a/lib/context.js
+++ b/lib/context.js
@@ -309,13 +309,18 @@
             var wrappedCallback = function(err, response) {
                 // Let's make sure that not only did the request succeed, but
                 // we actually got a non-empty session key back.
-                var hasSessionKey = !!(!err && response.data && response.data.sessionKey);
+                let resData = response.data,
+                    resSessionKey;
+                if(resData){
+                    resSessionKey = JSON.parse(resData).sessionKey;  
+                }
+                var hasSessionKey = !!(!err && resData && resSessionKey);
 
                 if (err || !hasSessionKey) {
                     callback(err || "No session key available", false);
                 }
                 else {
-                    that.sessionKey = response.data.sessionKey;
+                    that.sessionKey = resSessionKey;
                     callback(null, true);
                 }
             };


### PR DESCRIPTION
we are calling sessionKey on a string rather than an Object ("response.data.sessionKey"). so fixed the same. Crucial for Splunk server login.