### PR TITLE
WIP: Update to test splunk 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ node_js:
     - "0.12"
 
 env:
-    - SPLUNK_VERSION=7.3
     - SPLUNK_VERSION=8.0
+    - SPLUNK_VERSION=8.1
 
 before_script:
     node sdkdo hint


### PR DESCRIPTION
We maintain compatibility with the two most recent minor releases, updating to testing against Splunk 8.1 and 8.0, removing tests for 7.x