### PR TITLE
WIP: Enabled SSL verification for the REST API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ Then, to include the Splunk Enterprise SDK for JavaScript, use the `require` fun
 
 The following examples show you how to list search jobs using client-side and server-side code.
 
+* SSL velidation is enabled by default in the Splunk SDK JavaScript.
+* To connect with Splunk server set the SSL certificate as shown below,
+```javascript
+let service = new splunkjs.Service(...);
+let sslCert = fs.readFileSync('<cert-path>');
+service.setSSLCert(sslCert);
+```
+
+>**Note**: For local/Non-production/any other use cases SSL Certificate validation can be disabled as shown below
+```javascript
+let service = new splunkjs.Service(...);
+service.setValidateCertificates(false)
+```
+
 ### Client-side code example
 
 This HTML example uses the Splunk Enterprise SDK for JavaScript to list all jobs:
@@ -68,6 +82,9 @@ This HTML example uses the Splunk Enterprise SDK for JavaScript to list all jobs
     <script type="text/javascript" charset="utf-8">
         try {
             let service = new splunkjs.Service({username: "admin", password: "changed!"});
+            // read cert file and pass it as an argument in setSSLCert(<cert-file>) method
+            let ca = fs.readFileSync('<cert-path>');
+            service.setSSLCert(ca);
             await service.login();
             console.log("Login was successful");
             let jobs = await service.jobs().fetch();    
@@ -83,7 +100,7 @@ This HTML example uses the Splunk Enterprise SDK for JavaScript to list all jobs
 
 ### Node.js code example
 
-This example shows how to use the Splunk Enterprise SDK for JavaScript and Node.js to list all jobs:
+This example shows how to use the Splunk Enterprise SDK for JavaScript and Node.js to list all jobs:   
 
 ##### Login with username and password
 
@@ -91,6 +108,9 @@ This example shows how to use the Splunk Enterprise SDK for JavaScript and Node.
     let splunkjs = require('splunk-sdk');
 
     let service = new splunkjs.Service({username: "admin", password: "changed!"});
+    // read certificate and pass it as an argument in setSSLCert(<cert-file>) method
+    let ca = fs.readFileSync('<cert-path>');
+    service.setSSLCert(ca);
     try {
         await service.login();
         console.log("Login was successful: " + success);
@@ -120,6 +140,9 @@ let serviceWithSessionKey = new splunkjs.Service({
     sessionKey: SESSION_KEY, // Add your sessionKey here
     version: '9.0',
 });
+// read certificate and pass it as an argument in setSSLCert(<cert-file>) method
+let ca = fs.readFileSync('<cert-path>');
+serviceWithSessionKey.setSSLCert(ca);
 try {
     let jobs = await serviceWithSessionKey.jobs({ count: 1 });
     console.log("Login successful with sessionKey");
@@ -158,6 +181,9 @@ let serviceWithBearerToken = new splunkjs.Service({
     sessionKey: TOKEN, // Add your token here
     version: '8',
 });
+// read certificate and pass it as an argument in setSSLCert(<cert-file>) method
+let ca = fs.readFileSync('<cert-path>');
+serviceWithBearerToken.setSSLCert(ca);
 try {
     let res  = await serviceWithBearerToken.jobs({ count: 2 });
     console.log("Login successful with bearer token");

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Then, to include the Splunk Enterprise SDK for JavaScript, use the `require` fun
 
 The following examples show you how to list search jobs using client-side and server-side code.
 
-* SSL velidation is enabled by default in the Splunk SDK JavaScript.
+* SSL validation is enabled by default in the Splunk SDK JavaScript.
 * To connect with Splunk server set the SSL certificate as shown below,
 ```javascript
 let service = new splunkjs.Service(...);

--- a/lib/context.js
+++ b/lib/context.js
@@ -29,6 +29,9 @@
         "default": ""
     };
 
+    var validateCertificates = true;
+    var sslCert = undefined;
+
     /**
      * An abstraction over the Splunk HTTP-wire protocol that provides the basic
      * functionality for communicating with a Splunk instance over HTTP, handles
@@ -127,6 +130,8 @@
             this._requestWrapper  = utils.bind(this, this._requestWrapper);
             this.getInfo       = utils.bind(this, this.getInfo);
             this.disableV2SearchApi = utils.bind(this, this.disableV2SearchApi);
+            this.setValidateCertificates = utils.bind(this, this.setValidateCertificates);
+            this.setSSLCert = utils.bind(this, this.setSSLCert);
         },
 
         /**
@@ -260,7 +265,9 @@
                 this._headers(),
                 "",
                 this.timeout,
-                response_timeout
+                response_timeout,
+                validateCertificates,
+                sslCert
             ).then((response)=>{
                 let hasVersion = !!(response.data && response.data.generator.version);
                 let hasInstanceType = !!(response.data && response.data.generator["instance_type"]);
@@ -276,6 +283,30 @@
                 }
 
             });
+        },
+
+        /**
+         * Disable SSL certificate verification during REST API calls.
+         *
+         * @param {Boolean} validate_certificates A flag to enable and disable SSL certificate verification.
+         *
+         * @method splunkjs.Context
+         * @public
+         */
+        setValidateCertificates: function (validate_certificates) {
+            validateCertificates = validate_certificates;
+        },
+
+        /**
+         * Set SSL certificate for verification during REST API calls.
+         *
+         * @param {Buffer} ssl_cert An authority certificate to check the remote host against.
+         *
+         * @method splunkjs.Context
+         * @public
+         */
+        setSSLCert: function(ssl_cert) {
+            sslCert = ssl_cert;
         },
 
         /**
@@ -301,7 +332,9 @@
                 this._headers(),
                 params,
                 this.timeout,
-                response_timeout
+                response_timeout,
+                validateCertificates,
+                sslCert
             ).then((response)=>{
                 let hasSessionKey = !!(response.data && response.data.sessionKey);
                 if (!hasSessionKey) {
@@ -344,6 +377,8 @@
                     params,
                     that.timeout,
                     response_timeout,
+                    validateCertificates,
+                    sslCert,
                     true
                 );
             }
@@ -354,7 +389,9 @@
                         that._headers(),
                         params,
                         that.timeout,
-                        response_timeout
+                        response_timeout,
+                        validateCertificates,
+                        sslCert
                     );
                 };
     
@@ -378,7 +415,9 @@
                     that._headers(),
                     params,
                     that.timeout,
-                    response_timeout
+                    response_timeout,
+                    validateCertificates,
+                    sslCert
                 );
             };
 
@@ -401,7 +440,9 @@
                     that._headers(),
                     params,
                     that.timeout,
-                    response_timeout
+                    response_timeout,
+                    validateCertificates,
+                    sslCert
                 );
             };
 
@@ -421,7 +462,7 @@
          *
          * @method splunkjs.Context
          */
-        request: function(path, method, query, post, body, headers,response_timeout) {
+        request: function(path, method, query, post, body, headers, response_timeout) {
             var that = this;
             let request = function() {
                 return that.http.request(
@@ -432,7 +473,9 @@
                         query: query,
                         post: post,
                         body: body,
-                        timeout: that.timeout
+                        timeout: that.timeout,
+                        validateCertificates: validateCertificates,
+                        sslCert: sslCert
                     }
                 ,response_timeout);
             };

--- a/lib/http.js
+++ b/lib/http.js
@@ -129,14 +129,18 @@
          * @param {Object} params Parameters for this request.
          * @param {Number} timeout A timeout period.
          * @param {Number} response_timeout A timeout period for aborting a request in milisecs (0 means no timeout).
+         * @param {Boolean} validateCertificates A flag to enable and disable SSL certificate verification.
+         * @param {Buffer} sslCert An authority certificate to check the remote host against.
          *
          * @method splunkjs.Http
          */
-        get: function(url, headers, params, timeout, response_timeout, isAsync) {
+        get: function(url, headers, params, timeout, response_timeout, validateCertificates, sslCert, isAsync) {
             let message = {
                 method: "GET",
                 headers: headers,
                 timeout: timeout,
+                validateCertificates: validateCertificates,
+                sslCert: sslCert,
                 response_timeout: response_timeout,
                 query: params,
             };
@@ -151,15 +155,19 @@
          * @param {Object} params Parameters for this request.
          * @param {Number} timeout A timeout period.
          * @param {Number} response_timeout A timeout period for aborting a request in milisecs (0 means no timeout).
+         * @param {Boolean} validateCertificates A flag to enable and disable SSL certificate verification.
+         * @param {Buffer} sslCert An authority certificate to check the remote host against.
          *
          * @method splunkjs.Http
          */
-        post: function(url, headers, params, timeout, response_timeout) {
+        post: function(url, headers, params, timeout, response_timeout, validateCertificates, sslCert) {
             headers["Content-Type"] = "application/x-www-form-urlencoded";
             let message = {
                 method: "POST",
                 headers: headers,
                 timeout: timeout,
+                validateCertificates: validateCertificates,
+                sslCert: sslCert,
                 response_timeout: response_timeout,
                 post: params
             };
@@ -175,14 +183,18 @@
          * @param {Object} params Query parameters for this request.
          * @param {Number} timeout A timeout period.
          * @param {Number} response_timeout A timeout period for aborting a request in milisecs (0 means no timeout).
+         * @param {Boolean} validateCertificates A flag to enable and disable SSL certificate verification.
+         * @param {Buffer} sslCert An authority certificate to check the remote host against.
          *
          * @method splunkjs.Http
          */
-        del: function(url, headers, params, timeout, response_timeout) {
+        del: function(url, headers, params, timeout, response_timeout, validateCertificates, sslCert) {
             let message = {
                 method: "DELETE",
                 headers: headers,
                 timeout: timeout,
+                validateCertificates: validateCertificates,
+                sslCert: sslCert,
                 response_timeout: response_timeout,
                 query: params
             };
@@ -224,6 +236,8 @@
                 method: message.method,
                 headers: message.headers,
                 timeout: message.timeout,
+                validateCertificates: message.validateCertificates,
+                sslCert: message.sslCert,
                 response_timeout: message.response_timeout,
                 query: message.query,
                 body: body

--- a/lib/platform/node/node_http.js
+++ b/lib/platform/node/node_http.js
@@ -35,13 +35,24 @@
                 timeout: message.timeout || 0,
                 jar: false,
                 followAllRedirects: true,
-                strictSSL: false,
-                rejectUnauthorized : false
+                rejectUnauthorized : true
             };
 
             if(message.response_timeout != undefined){
                 request_options.response_timeout = message.response_timeout;
             }
+            
+            if(message.validateCertificates != undefined) {
+                request_options.rejectUnauthorized = message.validateCertificates;
+            }
+            if(request_options.rejectUnauthorized) {
+                if(message.sslCert == undefined){
+                    throw new Error("Set missing SSL Certificate for verification or Disable SSL verification and try again.")
+                } else {
+                    request_options.ca = message.sslCert;
+                }
+            }
+            
 
             // Get the byte-length of the content, which adjusts for multi-byte characters
             request_options.headers["Content-Length"] = Buffer.byteLength(request_options.body, "utf8");
@@ -96,14 +107,24 @@
                 timeout: message.timeout || 0,
                 jar: false,
                 followAllRedirects: true,
-                strictSSL: false,
-                rejectUnauthorized : false,
+                rejectUnauthorized: true
             };
 
             if(message.response_timeout != undefined){
                 request_options.response_timeout = message.response_timeout;
             }
             
+            if(message.validateCertificates != undefined) {
+                request_options.rejectUnauthorized = message.validateCertificates;
+            }
+            if(request_options.rejectUnauthorized) {
+                if(message.sslCert == undefined){
+                    throw new Error("Set missing SSL Certificate for verification or Disable SSL verification and try again.")
+                } else {
+                    request_options.ca = message.sslCert;
+                }
+            }
+
             // Get the byte-length of the content, which adjusts for multi-byte characters
             request_options.headers["Content-Length"] = Buffer.byteLength(request_options.body, "utf8");
             request_options.headers["User-Agent"] = "splunk-sdk-javascript/" + SDK_VERSION;

--- a/tests/test_http.js
+++ b/tests/test_http.js
@@ -19,6 +19,7 @@ exports.setup = function (http) {
 
     splunkjs.Logger.setLevel("ALL");
 
+    var sslVerification = false;
     return (
         describe("HTTP GET Tests", () => {
             before(function () {
@@ -28,7 +29,7 @@ exports.setup = function (http) {
             it("Timeout simple", async function () {
                 try {
                     //Response timeout set to 1ms i.e service call will abort after 1ms
-                    let res = await this.http.get("https://httpbin.org/get", {}, {}, 0, response_timeout = 1);
+                    let res = await this.http.get("https://httpbin.org/get", {}, {}, 0, response_timeout = 1, sslVerification);
                     assert.ok(!res);
                 } catch (error) {
                     assert.ok(error);
@@ -38,7 +39,7 @@ exports.setup = function (http) {
 
             it("Timeout delay", async function () {
                 try {
-                    let req = await this.http.get("https://httpbin.org/delay/20", {}, {}, 0, response_timeout = 1000);
+                    let req = await this.http.get("https://httpbin.org/delay/20", {}, {}, 0, response_timeout = 1000, sslVerification);
                     assert.ok(!req);
                 } catch (error) {
                     assert.ok(error);
@@ -47,13 +48,13 @@ exports.setup = function (http) {
             });
 
             it("No args", async function () {
-                let res = await this.http.get("https://httpbin.org/get", [], {}, 0);
+                let res = await this.http.get("https://httpbin.org/get", [], {}, 0, 0, sslVerification);
                 assert.strictEqual(res.data.url, "https://httpbin.org/get");
             });
 
             it("Success and Error", async function () {
                 try {
-                    let res = await this.http.get("https://httpbin.org/get", [], {}, 0);
+                    let res = await this.http.get("https://httpbin.org/get", [], {}, 0, 0, sslVerification);
                     assert.strictEqual(res.data.url, "https://httpbin.org/get");
                 } catch (error) {
                     assert.ok(!error);
@@ -63,7 +64,7 @@ exports.setup = function (http) {
             it("Error all", async function () {
                 this.timeout(40000);
                 try {
-                    let res = await this.http.get("https://httpbin.org/status/404", [], {}, 0);
+                    let res = await this.http.get("https://httpbin.org/status/404", [], {}, 0, 0, sslVerification);
                     assert.ok(!res);
                 } catch (error) {
                     assert.strictEqual(error.status, 404);
@@ -72,7 +73,7 @@ exports.setup = function (http) {
 
             it("With args", async function () {
                 this.timeout(40000);
-                let res = await this.http.get("https://httpbin.org/get", [], { a: 1, b: 2, c: [1, 2, 3], d: "a/b" }, 0);
+                let res = await this.http.get("https://httpbin.org/get", [], { a: 1, b: 2, c: [1, 2, 3], d: "a/b" }, 0, 0, sslVerification);
                 let args = res.data.args;
                 assert.strictEqual(args.a, "1");
                 assert.strictEqual(args.b, "2");
@@ -83,7 +84,7 @@ exports.setup = function (http) {
 
             it("Args with objects", async function () {
                 this.timeout(40000);
-                let res = await this.http.get("https://httpbin.org/get", [], { a: 1, b: { c: "ab", d: 12 } }, 0);
+                let res = await this.http.get("https://httpbin.org/get", [], { a: 1, b: { c: "ab", d: 12 } }, 0, 0, sslVerification);
                 let args = res.data.args;
                 assert.strictEqual(args.a, "1");
                 assert.deepEqual(args.b, ["ab", "12"]);
@@ -95,7 +96,7 @@ exports.setup = function (http) {
 
             it("With headers", async function () {
                 let headers = { "X-Test1": 1, "X-Test2": "a/b/c" };
-                let res = await this.http.get("https://httpbin.org/get", { "X-Test1": 1, "X-Test2": "a/b/c" }, {}, 0);
+                let res = await this.http.get("https://httpbin.org/get", { "X-Test1": 1, "X-Test2": "a/b/c" }, {}, 0, 0, sslVerification);
                 let returnedHeaders = res.data.headers;
                 for (let headerName in headers) {
                     // We have to make the header values into strings
@@ -108,7 +109,7 @@ exports.setup = function (http) {
             it("All", async function () {
                 let headers = { "X-Test1": 1, "X-Test2": "a/b/c" };
 
-                let res = await this.http.get("https://httpbin.org/get", { "X-Test1": 1, "X-Test2": "a/b/c" }, { a: 1, b: 2, c: [1, 2, 3], d: "a/b" }, 0);
+                let res = await this.http.get("https://httpbin.org/get", { "X-Test1": 1, "X-Test2": "a/b/c" }, { a: 1, b: 2, c: [1, 2, 3], d: "a/b" }, 0, 0, sslVerification);
                 let returnedHeaders = res.data.headers;
                 for (let headerName in headers) {
                     // We have to make the header values into strings
@@ -130,13 +131,13 @@ exports.setup = function (http) {
             });
 
             it("No args", async function () {
-                let res = await this.http.post("https://httpbin.org/post", {}, {}, 0);
+                let res = await this.http.post("https://httpbin.org/post", {}, {}, 0, 0, sslVerification);
                 assert.strictEqual(res.data.url, "https://httpbin.org/post");
             });
 
             it("Success and error", async function () {
                 try {
-                    let res = await this.http.post("https://httpbin.org/post", {}, {}, 0);
+                    let res = await this.http.post("https://httpbin.org/post", {}, {}, 0, 0, sslVerification);
                     assert.strictEqual(res.data.url, "https://httpbin.org/post");
                 } catch (error) {
                     assert.ok(!error);
@@ -145,7 +146,7 @@ exports.setup = function (http) {
 
             it("Error all", async function () {
                 try {
-                    let res = await this.http.post("https://httpbin.org/status/405", {}, {}, 0);
+                    let res = await this.http.post("https://httpbin.org/status/405", {}, {}, 0, 0, sslVerification);
                     assert.ok(!res);
                 } catch (error) {
                     assert.strictEqual(error.status, 405);
@@ -153,7 +154,7 @@ exports.setup = function (http) {
             });
 
             it("With args", async function () {
-                let res = await this.http.post("https://httpbin.org/post", {}, { a: 1, b: 2, c: [1, 2, 3], d: "a/b" }, 0);
+                let res = await this.http.post("https://httpbin.org/post", {}, { a: 1, b: 2, c: [1, 2, 3], d: "a/b" }, 0, 0, sslVerification);
                 let args = res.data.form;
                 assert.strictEqual(args.a, "1");
                 assert.strictEqual(args.b, "2");
@@ -165,7 +166,7 @@ exports.setup = function (http) {
             it("Headers", async function () {
                 let headers = { "X-Test1": 1, "X-Test2": "a/b/c" };
 
-                let res = await this.http.post("https://httpbin.org/post", { "X-Test1": 1, "X-Test2": "a/b/c" }, {}, 0);
+                let res = await this.http.post("https://httpbin.org/post", { "X-Test1": 1, "X-Test2": "a/b/c" }, {}, 0, 0, sslVerification);
                 let returnedHeaders = res.data.headers;
                 for (let headerName in headers) {
                     // We have to make the header values into strings
@@ -177,7 +178,7 @@ exports.setup = function (http) {
             it("All", async function () {
                 let headers = { "X-Test1": 1, "X-Test2": "a/b/c" };
 
-                let res = await this.http.post("https://httpbin.org/post", { "X-Test1": 1, "X-Test2": "a/b/c" }, { a: 1, b: 2, c: [1, 2, 3], d: "a/b" }, 0);
+                let res = await this.http.post("https://httpbin.org/post", { "X-Test1": 1, "X-Test2": "a/b/c" }, { a: 1, b: 2, c: [1, 2, 3], d: "a/b" }, 0, 0, sslVerification);
                 let returnedHeaders = res.data.headers;
                 for (let headerName in headers) {
                     // We have to make the header values into strings
@@ -199,13 +200,13 @@ exports.setup = function (http) {
             });
 
             it("No args", async function () {
-                let res = await this.http.del("https://httpbin.org/delete", [], {}, 0);
+                let res = await this.http.del("https://httpbin.org/delete", [], {}, 0, 0, sslVerification);
                 assert.strictEqual(res.data.url, "https://httpbin.org/delete");
             });
 
             it("Success and error", async function () {
                 try {
-                    let res = await this.http.del("https://httpbin.org/delete", [], {}, 0);
+                    let res = await this.http.del("https://httpbin.org/delete", [], {}, 0, 0, sslVerification);
                     assert.strictEqual(res.data.url, "https://httpbin.org/delete");
                 } catch (error) {
                     assert.ok(!error);
@@ -214,7 +215,7 @@ exports.setup = function (http) {
 
             it("Error all", async function () {
                 try {
-                    let res = await this.http.del("https://httpbin.org/status/405", [], {}, 0);
+                    let res = await this.http.del("https://httpbin.org/status/405", [], {}, 0, 0, sslVerification);
                     assert.ok(!res);
                 } catch (error) {
                     assert.strictEqual(error.status, 405);
@@ -222,14 +223,14 @@ exports.setup = function (http) {
             });
 
             it("Args", async function () {
-                let res = await this.http.del("https://httpbin.org/delete", [], { a: 1, b: 2, c: [1, 2, 3], d: "a/b" }, 0);
+                let res = await this.http.del("https://httpbin.org/delete", [], { a: 1, b: 2, c: [1, 2, 3], d: "a/b" }, 0, 0, sslVerification);
                 assert.strictEqual(res.data.url, "https://httpbin.org/delete?a=1&b=2&c=1&c=2&c=3&d=a%2Fb");
             });
 
             it("Headers", async function () {
                 let headers = { "X-Test1": 1, "X-Test2": "a/b/c" };
 
-                let res = await this.http.del("https://httpbin.org/delete", { "X-Test1": 1, "X-Test2": "a/b/c" }, {}, 0);
+                let res = await this.http.del("https://httpbin.org/delete", { "X-Test1": 1, "X-Test2": "a/b/c" }, {}, 0, 0, sslVerification);
                 let returnedHeaders = res.data.headers;
                 for (let headerName in headers) {
                     if (headers.hasOwnProperty(headerName)) {
@@ -243,7 +244,7 @@ exports.setup = function (http) {
             it("All", async function () {
                 let headers = { "X-Test1": 1, "X-Test2": "a/b/c" };
 
-                let res = await this.http.del("https://httpbin.org/delete", { "X-Test1": 1, "X-Test2": "a/b/c" }, { a: 1, b: 2, c: [1, 2, 3], d: "a/b" }, 0);
+                let res = await this.http.del("https://httpbin.org/delete", { "X-Test1": 1, "X-Test2": "a/b/c" }, { a: 1, b: 2, c: [1, 2, 3], d: "a/b" }, 0, 0, sslVerification);
                 let returnedHeaders = res.data.headers;
                 for (let headerName in headers) {
                     if (headers.hasOwnProperty(headerName)) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -64,6 +64,7 @@ describe("Server tests", function () {
 
     this.beforeAll(async function () {
         try {
+            svc.setValidateCertificates(false);
             await svc.login();
         } catch (error) {
             throw new Error("Login failed - not running tests", error || "");


### PR DESCRIPTION
- By default enabled SSL verification in SDK
- added two new methods, `setValidateCertificates()` to disable ssl verification and `setSSLCert()` to set SSL certificate while SSL is enabled.